### PR TITLE
Fix API not working because all fields are empty string ('') bug

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,7 +7,7 @@ const prepareBodyWithSign = async (
   signerAddress: string,
   sign: SignerFunction,
   payload?: object
-): Promise<string> => {
+): Promise<PreparedBody> => {
   if (!isAddress(signerAddress))
     throw new Error(`Invalid address: ${signerAddress} !`);
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -39,7 +39,7 @@ const prepareBodyWithSign = async (
     },
   };
 
-  return stringify(body);
+  return body;
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/client.ts
+++ b/src/client.ts
@@ -79,7 +79,7 @@ const guild = {
     sign: SignerFunction,
     params: CreateGuildParams
   ): Promise<CreateGuildResponse> {
-    const body = prepareBodyWithSign(signerAddress, sign, params);
+    const body = await prepareBodyWithSign(signerAddress, sign, params);
     try {
       const res = await axios.post(`${API_BASE_URL}/guild`, body, { headers });
       return res.data;
@@ -99,7 +99,7 @@ const guild = {
     sign: SignerFunction,
     params: UpdateGuildParams
   ) {
-    const body = prepareBodyWithSign(signerAddress, sign, params);
+    const body = await prepareBodyWithSign(signerAddress, sign, params);
     try {
       const res = await axios.patch(`${API_BASE_URL}/guild/${id}`, body, {
         headers,
@@ -119,7 +119,7 @@ const guild = {
     signerAddress: string,
     sign: SignerFunction
   ): Promise<DeleteGuildResponse> {
-    const body = prepareBodyWithSign(signerAddress, sign);
+    const body = await prepareBodyWithSign(signerAddress, sign);
     try {
       const res = await axios.delete(`${API_BASE_URL}/guild/${id}`, {
         data: body,
@@ -141,7 +141,7 @@ const guild = {
     sign: SignerFunction
   ): Promise<JoinResponse> {
     try {
-      const body = prepareBodyWithSign(signerAddress, sign, { guildId });
+      const body = await prepareBodyWithSign(signerAddress, sign, { guildId });
       const res = await axios.post(`${API_BASE_URL}/user/join/`, body, {
         headers,
       });
@@ -170,7 +170,7 @@ const role = {
     sign: SignerFunction,
     params: CreateRoleParams
   ): Promise<CreateRoleResponse> {
-    const body = prepareBodyWithSign(signerAddress, sign, params);
+    const body = await prepareBodyWithSign(signerAddress, sign, params);
     try {
       const res = await axios.post(`${API_BASE_URL}/role`, body, { headers });
       return res.data;
@@ -189,7 +189,7 @@ const role = {
     sign: SignerFunction,
     params: UpdateRoleParams
   ): Promise<UpdateRoleResponse> {
-    const body = prepareBodyWithSign(signerAddress, sign, params);
+    const body = await prepareBodyWithSign(signerAddress, sign, params);
     try {
       const res = await axios.patch(`${API_BASE_URL}/role/${id}`, body, {
         headers,
@@ -209,7 +209,7 @@ const role = {
     signerAddress: string,
     sign: SignerFunction
   ): Promise<DeleteRoleResponse> {
-    const body = prepareBodyWithSign(signerAddress, sign);
+    const body = await prepareBodyWithSign(signerAddress, sign);
     try {
       const res = await axios.delete(`${API_BASE_URL}/role/${id}`, {
         data: body,


### PR DESCRIPTION
## Problem
![image](https://user-images.githubusercontent.com/4103490/163706144-5a36fe99-1cbc-4be7-8ca8-329eb60ad8f1.png)

## How I fixed
1. remove stringify from prepareBodyWithSign return
2. change prepareBodyWithSign return type to PreparedBody Promise
3. add await to all prepareBodyWithSign usage